### PR TITLE
use addAddonToProject in default blueprint

### DIFF
--- a/blueprints/nypr-player/index.js
+++ b/blueprints/nypr-player/index.js
@@ -10,6 +10,6 @@ module.exports = {
   // }
 
   afterInstall: function() {
-    return this.addPackageToProject('ember-hifi');
+    return this.addAddonToProject('ember-hifi');
   }
 };


### PR DESCRIPTION
otherwise it won't run `ember-hifi`'s default blueprint and then you won't have howler or hls installed (see circle)