### PR TITLE
Don't use compass

### DIFF
--- a/app/styles/nypr-player.scss
+++ b/app/styles/nypr-player.scss
@@ -1,4 +1,3 @@
-@import "compass";
 @import "nypr-ui";
 @import "nypr-player/variables";
 @import "nypr-player/mixins";
@@ -35,17 +34,17 @@
 
 .nypr-player .ember-holygrail-left {
   min-width: 153px;
-  @include flex(0 1 153px);
+  flex: 0 1 153px;
 
   @include mq($nypr-player-medium-and-up) {
     min-width: 230px;
-    @include flex(0 1 230px);
+    flex:0 1 230px;
   }
 }
 
 .nypr-player .nypr-player-controls {
-  @include display-flex;
-  @include align-items(left);
+  display: flex;
+  align-items: left;
 
   width: 100%;
   margin: 3.5px;
@@ -55,7 +54,7 @@
 }
 
 .nypr-player .ember-holygrail-left .nypr-player-controls {
-  @include justify-content(flex-start);
+  justify-content: flex-start;
 
   @include mq($nypr-player-medium-and-up) {
     margin: 0px;
@@ -63,7 +62,7 @@
 }
 
 .nypr-player .ember-holygrail-right .nypr-player-controls {
-  @include justify-content(flex-end);
+  justify-content: flex-end;
 
   @include mq($nypr-player-medium-and-up) {
     margin-right: 4px;
@@ -72,7 +71,7 @@
 
 .nypr-player .ember-holygrail-middle {
   min-width: 0;
-  @include flex(1 0 0);
+  flex: 1 0 0;
 }
 
 /* Metadata */
@@ -108,11 +107,11 @@
 
 .nypr-player-progress-container {
   @include mq($nypr-player-medium-and-up) {
-    @include display-flex;
-    @include align-items(center);
+    display: flex;
+    align-items: center;
 
     > .nypr-player-progress {
-      @include flex(1);
+      flex: 1;
       position: relative;
       bottom: 0;
       margin: 0 15px 0 0;
@@ -126,7 +125,7 @@
     }
 
     > .nypr-player-timelabel {
-      @include flex(0 0 auto);
+      flex: 0 0 auto;
     }
   }
 }
@@ -160,7 +159,7 @@
   background-image: none;
 
   @include mq($nypr-player-medium-and-up) {
-    @include display-flex(inline-flex);
+    display: inline-flex;
   }
 }
 
@@ -190,11 +189,11 @@
 .nypr-player.is-audiostream {
   .ember-holygrail-left {
     min-width: 90px;
-    @include flex(0 0 90px);
+    flex: 0 0 90px;
 
     @include mq($nypr-player-medium-and-up) {
       min-width: 95px;
-      @include flex(0 0 95px);
+      flex: 0 0 95px;
     }
   }
 

--- a/app/styles/nypr-player/_buttons.scss
+++ b/app/styles/nypr-player/_buttons.scss
@@ -3,14 +3,14 @@
   > .nypr-player-icon {
     height: 100%;
     width: $width;
-    @include transition(color $nypr-player-transition-timing ease-in-out, opacity $nypr-player-transition-timing ease-in-out);
+    transition: color $nypr-player-transition-timing ease-in-out, opacity $nypr-player-transition-timing ease-in-out;
     pointer-events: none;
   }
 }
 
 .nypr-player-button {
-  @include btn();
-  @include blank-button();
+  @include btn;
+  @include blank-button;
   @include svg-color($nypr-player-button-color);
   height: 100%;
 
@@ -61,7 +61,7 @@
     margin: auto;
 
     display: block;
-    @include transition(fill $nypr-player-transition-timing ease-in-out, opacity $nypr-player-transition-timing ease-in-out);
+    transition: fill $nypr-player-transition-timing ease-in-out, opacity $nypr-player-transition-timing ease-in-out;
     transform: translateZ(0);
     will-change: fill,opacity;
   }
@@ -69,11 +69,11 @@
   position: relative;
 
   .listen-spinner {
-    @include spinner()
+    @include spinner;
   }
   .listen-spinner:after, .listen-spinner:before{
     display: inline-block;
-    @include transition(opacity 150ms ease);
+    transition: opacity 150ms ease;
   }
 
   &.is-paused {
@@ -261,7 +261,7 @@
   margin-right: 15px;
   border: 0;
   outline: 0;
-  @include display-flex;
+  display: flex;
   height: 100%;
 
   &.is-floating {
@@ -271,7 +271,7 @@
     border: none;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
     background: $nypr-player-floating-queue-button-background;
-    @include transition(color $nypr-player-transition-timing ease-in-out);
+    transition: color $nypr-player-transition-timing ease-in-out;
 
     .nypr-player-queue-icon {
       &.mod-close {
@@ -338,12 +338,12 @@
   top: 43px;
   font-size: 12px;
   font-weight: 600;
-  @include transition(color $nypr-player-transition-timing ease-in-out);
+  transition: color $nypr-player-transition-timing ease-in-out;
 }
 
 /* This isn't using the player-icon class because this is a different animal */
 .nypr-player-queue-icon {
-  @include transition(opacity $nypr-player-transition-timing ease-in-out);
+  transition: opacity $nypr-player-transition-timing ease-in-out;
   width: 19px;
   height: 19px;
   top: -18px;
@@ -361,7 +361,7 @@
   > .nypr-player-queue-bar {
     background: $nypr-player-button-color;
     position: absolute;
-    @include transition(background $nypr-player-transition-timing ease-in-out);
+    transition: background $nypr-player-transition-timing ease-in-out;
   }
 
   > .nypr-player-queue-dot {

--- a/app/styles/nypr-player/_mixins.scss
+++ b/app/styles/nypr-player/_mixins.scss
@@ -81,7 +81,7 @@ $nypr-player-base-font: 16;
   polygon, rect, circle, path {
     color: $color;
     fill: currentColor;
-    @include transition(color $nypr-player-transition-timing ease-in-out, stroke $nypr-player-transition-timing ease-in-out, fill $nypr-player-transition-timing ease-in-out);
+    transition: color $nypr-player-transition-timing ease-in-out, stroke $nypr-player-transition-timing ease-in-out, fill $nypr-player-transition-timing ease-in-out;
   }
 }
 

--- a/app/styles/nypr-player/_progress.scss
+++ b/app/styles/nypr-player/_progress.scss
@@ -8,7 +8,7 @@
   left: 0;
   right: 0;
   cursor: pointer;
-  @include display-flex;
+  display: flex;
 }
 
 .nypr-player-progress-wrapper,
@@ -61,7 +61,7 @@
     left: 0;
     opacity: 0;
     bottom: 0;
-    @include transition(opacity 200ms linear, transform 200ms);
+    transition: opacity 200ms linear, transform 200ms;
 
     .is-loaded & {
       opacity: 1;
@@ -76,7 +76,7 @@
     .touchevents .nypr-player-progress.is-touching &  {
       transform: scale(3.3, 3.3) translateY(-7px);
       opacity: 0.75;
-      @include transition(opacity 200ms linear 200ms, transform 200ms ease-out 200ms);
+      transition: opacity 200ms linear 200ms, transform 200ms ease-out 200ms;
     }
 
     &:after {

--- a/app/styles/nypr-player/_volume.scss
+++ b/app/styles/nypr-player/_volume.scss
@@ -10,7 +10,7 @@ $slider-spacing: $slider-spacing-left + $slider-spacing-right;
 .nypr-player-volume {
   margin-left: 42px;
   margin-right: 18px;
-  @include display-flex;
+  display: flex;
   height: 100%;
 }
 
@@ -22,7 +22,7 @@ $slider-spacing: $slider-spacing-left + $slider-spacing-right;
 }
 
 .nypr-player-volume-control {
-  @include display-flex;
+  display: flex;
   height: 100%;
   cursor: pointer;
   outline: 0;
@@ -33,7 +33,7 @@ $slider-spacing: $slider-spacing-left + $slider-spacing-right;
   &:focus {
     .nypr-player-volume-slider-wrapper, {
       width: $slider-width + $slider-spacing;
-      @include transition(width .3s cubic-bezier(0.4, 0.4, 0.265, 1.55));
+      transition: width .3s cubic-bezier(0.4, 0.4, 0.265, 1.55);
     }
   }
 }
@@ -47,7 +47,7 @@ $slider-spacing: $slider-spacing-left + $slider-spacing-right;
   overflow: hidden;
   // when transitioning width to 0, make sure bezier curve doesn't go above the 1 line, because that will
   // cause width to go negative in safari and probably have unintended effects.
-  @include transition(width .3s cubic-bezier(0.4, 0.4, 0.265, 0.99));
+  transition: width .3s cubic-bezier(0.4, 0.4, 0.265, 0.99);
 }
 
 .nypr-player-volume-slider {
@@ -87,7 +87,7 @@ $slider-spacing: $slider-spacing-left + $slider-spacing-right;
   background: $nypr-player-slider-handle-color;
   margin-top: -$handle-radius;
   left: 100%;
-  @include translateX(-$handle-radius);
+  transform: translateX(-$handle-radius);
 }
 
 .nypr-player-button.mod-volume {

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,10 @@
 machine:
   node:
-    version: 6.9.2
+    version: 6.11.3
 
 dependencies:
   override:
-    - sudo apt-get update && sudo apt-get install ruby-sass
-    - gem update --system
-    - gem install compass --no-ri --no-rdoc
-    - yarn
-  cache_directories:
-    - /opt/circleci/nodejs/v6.9.2/bin/
-    - /opt/circleci/nodejs/v6.9.2/lib/node_modules
+    - yarn --pure-lockfile
 
 test:
   override:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-moment-shim": "^3.4.0",
+    "ember-cli-sass": "^7.0.0",
     "ember-hifi": "^1.11.1",
     "ember-moment": "^7.4.1",
     "nypr-ui": "nypublicradio/nypr-ui"
@@ -30,7 +31,6 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.14.1",
-    "ember-cli-compass-compiler": "^0.5.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-sass": "^7.0.0",
     "ember-hifi": "^1.11.1",
     "ember-moment": "^7.4.1",
-    "nypr-ui": "nypublicradio/nypr-ui"
+    "nypr-ui": "nypublicradio/nypr-ui#node-sass"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-sass": "^7.0.0",
     "ember-hifi": "^1.11.1",
     "ember-moment": "^7.4.1",
-    "nypr-ui": "nypublicradio/nypr-ui#node-sass"
+    "nypr-ui": "nypublicradio/nypr-ui"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4771,7 +4771,7 @@ number-is-nan@^1.0.0:
 
 nypr-ui@nypublicradio/nypr-ui#node-sass:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/7d95d21c93184284c21953f579ca41eaae91f25d"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/74835c61a1bf1489f7f002b0b81b5630b37874d4"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,19 @@ broccoli-builder@^0.18.8:
     rsvp "^3.0.17"
     silent-error "^1.0.1"
 
+broccoli-caching-writer@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz#1b7d5e69bcdfe11b41c9f44bf69f8908298a2b91"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.2.5"
+    broccoli-plugin "1.1.0"
+    debug "^2.1.1"
+    lodash.assign "^3.2.0"
+    rimraf "^2.2.8"
+    rsvp "^3.0.17"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.2.5"
+
 broccoli-caching-writer@^2.0.4, broccoli-caching-writer@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz#b93cf58f9264f003075868db05774f4e7f25bd07"
@@ -1187,6 +1200,14 @@ broccoli-clean-css@^1.1.0:
     clean-css-promise "^0.1.0"
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
+
+broccoli-compass-compiler@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/broccoli-compass-compiler/-/broccoli-compass-compiler-0.0.6.tgz#fbf1d5b6747ad46f520a9333578de053063c3153"
+  dependencies:
+    broccoli-caching-writer "2.2.1"
+    compass-compile "0.0.1"
+    merge "^1.2.0"
 
 broccoli-concat@^3.2.2:
   version "3.2.2"
@@ -1250,6 +1271,23 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
+broccoli-funnel@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz#12cb76e342343592a3b18ae7840c0db3bd16d8af"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.0.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.3.0"
+    minimatch "^2.0.1"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.2.6"
+
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
@@ -1294,6 +1332,18 @@ broccoli-lint-eslint@^3.3.0:
     json-stable-stringify "^1.0.1"
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
+
+broccoli-merge-trees@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz#1e283d18c686da922bb91a80d7aac0d161388e21"
+  dependencies:
+    broccoli-plugin "^1.0.0"
+    can-symlink "^1.0.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.2"
+    fs-tree-diff "^0.4.3"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
 
 broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.2.0:
   version "1.2.4"
@@ -1739,6 +1789,14 @@ commoner@~0.10.3:
     q "^1.1.2"
     recast "^0.11.17"
 
+compass-compile@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/compass-compile/-/compass-compile-0.0.1.tgz#a078a7c0d43c20f7be47bb9122a98aa70261c930"
+  dependencies:
+    dargs "^4.0.1"
+    merge "^1.2.0"
+    rsvp "^3.1.0"
+
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -1904,6 +1962,12 @@ d@1:
 dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
+
+dargs@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
+  dependencies:
+    number-is-nan "^1.0.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2131,6 +2195,17 @@ ember-cli-broccoli-sane-watcher@^2.0.4:
     heimdalljs-logger "^0.1.7"
     rsvp "^3.0.18"
     sane "^1.1.1"
+
+ember-cli-compass-compiler@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-compass-compiler/-/ember-cli-compass-compiler-0.5.0.tgz#b44000846f9e04b077042f9fb0fd67ae1a4c072e"
+  dependencies:
+    broccoli-compass-compiler "0.0.6"
+    broccoli-funnel "1.0.1"
+    broccoli-merge-trees "1.1.1"
+    ember-cli-version-checker "^1.1.4"
+    glob "^6.0.4"
+    merge "^1.2.0"
 
 ember-cli-dependency-checker@^1.3.0:
   version "1.4.0"
@@ -3247,6 +3322,20 @@ fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
 
+fs-tree-diff@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz#41a84ee34994bd564c63d9852f1109c5de7f9290"
+  dependencies:
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.2"
+
+fs-tree-diff@^0.4.3:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz#f6b75d70db22c1f3b05d592270f4ed6c9c2f82dd"
+  dependencies:
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.2"
+
 fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz#342665749e8dca406800b672268c8f5073f3e623"
@@ -3362,6 +3451,16 @@ glob@7.1.1:
 glob@^5.0.10, glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -4380,7 +4479,7 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-merge@^1.1.3:
+merge@^1.1.3, merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -4426,7 +4525,7 @@ mime@1.3.4, mime@^1.2.11:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^2.0.3:
+minimatch@^2.0.1, minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
@@ -4672,13 +4771,13 @@ number-is-nan@^1.0.0:
 
 nypr-ui@nypublicradio/nypr-ui#node-sass:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/f4a1d4904f27e43ef25150d9f0a5a670d1212e02"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/cf3c8820607f2af9eb7a2784830feb15fc43f07e"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"
-    ember-cli-compass-compiler "^0.5.0"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^0.4.3"
+    ember-cli-sass "^7.0.0"
     ember-click-outside "0.1.9"
     ember-composable-helpers "2.0.1"
     ember-holygrail-layout "^0.1.4"
@@ -6133,7 +6232,7 @@ walk-sync@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.1.3.tgz#8a07261a00bda6cfb1be25e9f100fad57546f583"
 
-walk-sync@^0.2.5, walk-sync@^0.2.7:
+walk-sync@^0.2.5, walk-sync@^0.2.6, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4771,7 +4771,7 @@ number-is-nan@^1.0.0:
 
 nypr-ui@nypublicradio/nypr-ui#node-sass:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/cf3c8820607f2af9eb7a2784830feb15fc43f07e"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/7d95d21c93184284c21953f579ca41eaae91f25d"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,19 +1157,6 @@ broccoli-builder@^0.18.8:
     rsvp "^3.0.17"
     silent-error "^1.0.1"
 
-broccoli-caching-writer@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz#1b7d5e69bcdfe11b41c9f44bf69f8908298a2b91"
-  dependencies:
-    broccoli-kitchen-sink-helpers "^0.2.5"
-    broccoli-plugin "1.1.0"
-    debug "^2.1.1"
-    lodash.assign "^3.2.0"
-    rimraf "^2.2.8"
-    rsvp "^3.0.17"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.2.5"
-
 broccoli-caching-writer@^2.0.4, broccoli-caching-writer@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz#b93cf58f9264f003075868db05774f4e7f25bd07"
@@ -1200,14 +1187,6 @@ broccoli-clean-css@^1.1.0:
     clean-css-promise "^0.1.0"
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
-
-broccoli-compass-compiler@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/broccoli-compass-compiler/-/broccoli-compass-compiler-0.0.6.tgz#fbf1d5b6747ad46f520a9333578de053063c3153"
-  dependencies:
-    broccoli-caching-writer "2.2.1"
-    compass-compile "0.0.1"
-    merge "^1.2.0"
 
 broccoli-concat@^3.2.2:
   version "3.2.2"
@@ -1271,23 +1250,6 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz#12cb76e342343592a3b18ae7840c0db3bd16d8af"
-  dependencies:
-    array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^1.0.0"
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.0"
-    fs-tree-diff "^0.3.0"
-    minimatch "^2.0.1"
-    mkdirp "^0.5.0"
-    path-posix "^1.0.0"
-    rimraf "^2.4.3"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.2.6"
-
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
@@ -1332,18 +1294,6 @@ broccoli-lint-eslint@^3.3.0:
     json-stable-stringify "^1.0.1"
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
-
-broccoli-merge-trees@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz#1e283d18c686da922bb91a80d7aac0d161388e21"
-  dependencies:
-    broccoli-plugin "^1.0.0"
-    can-symlink "^1.0.0"
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.2"
-    fs-tree-diff "^0.4.3"
-    rimraf "^2.4.3"
-    symlink-or-copy "^1.0.0"
 
 broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.2.0:
   version "1.2.4"
@@ -1789,14 +1739,6 @@ commoner@~0.10.3:
     q "^1.1.2"
     recast "^0.11.17"
 
-compass-compile@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/compass-compile/-/compass-compile-0.0.1.tgz#a078a7c0d43c20f7be47bb9122a98aa70261c930"
-  dependencies:
-    dargs "^4.0.1"
-    merge "^1.2.0"
-    rsvp "^3.1.0"
-
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -1962,12 +1904,6 @@ d@1:
 dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
-
-dargs@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
-  dependencies:
-    number-is-nan "^1.0.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2195,17 +2131,6 @@ ember-cli-broccoli-sane-watcher@^2.0.4:
     heimdalljs-logger "^0.1.7"
     rsvp "^3.0.18"
     sane "^1.1.1"
-
-ember-cli-compass-compiler@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-compass-compiler/-/ember-cli-compass-compiler-0.5.0.tgz#b44000846f9e04b077042f9fb0fd67ae1a4c072e"
-  dependencies:
-    broccoli-compass-compiler "0.0.6"
-    broccoli-funnel "1.0.1"
-    broccoli-merge-trees "1.1.1"
-    ember-cli-version-checker "^1.1.4"
-    glob "^6.0.4"
-    merge "^1.2.0"
 
 ember-cli-dependency-checker@^1.3.0:
   version "1.4.0"
@@ -3322,20 +3247,6 @@ fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
 
-fs-tree-diff@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz#41a84ee34994bd564c63d9852f1109c5de7f9290"
-  dependencies:
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.2"
-
-fs-tree-diff@^0.4.3:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz#f6b75d70db22c1f3b05d592270f4ed6c9c2f82dd"
-  dependencies:
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.2"
-
 fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz#342665749e8dca406800b672268c8f5073f3e623"
@@ -3451,16 +3362,6 @@ glob@7.1.1:
 glob@^5.0.10, glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -4479,7 +4380,7 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-merge@^1.1.3, merge@^1.2.0:
+merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -4525,7 +4426,7 @@ mime@1.3.4, mime@^1.2.11:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^2.0.1, minimatch@^2.0.3:
+minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
@@ -4769,9 +4670,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nypr-ui@nypublicradio/nypr-ui:
+nypr-ui@nypublicradio/nypr-ui#node-sass:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/cab9362b6c7498998f759b1237b8c9642d6af876"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/f4a1d4904f27e43ef25150d9f0a5a670d1212e02"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"
@@ -6232,7 +6133,7 @@ walk-sync@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.1.3.tgz#8a07261a00bda6cfb1be25e9f100fad57546f583"
 
-walk-sync@^0.2.5, walk-sync@^0.2.6, walk-sync@^0.2.7:
+walk-sync@^0.2.5, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,19 +1157,6 @@ broccoli-builder@^0.18.8:
     rsvp "^3.0.17"
     silent-error "^1.0.1"
 
-broccoli-caching-writer@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz#1b7d5e69bcdfe11b41c9f44bf69f8908298a2b91"
-  dependencies:
-    broccoli-kitchen-sink-helpers "^0.2.5"
-    broccoli-plugin "1.1.0"
-    debug "^2.1.1"
-    lodash.assign "^3.2.0"
-    rimraf "^2.2.8"
-    rsvp "^3.0.17"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.2.5"
-
 broccoli-caching-writer@^2.0.4, broccoli-caching-writer@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz#b93cf58f9264f003075868db05774f4e7f25bd07"
@@ -1200,14 +1187,6 @@ broccoli-clean-css@^1.1.0:
     clean-css-promise "^0.1.0"
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
-
-broccoli-compass-compiler@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/broccoli-compass-compiler/-/broccoli-compass-compiler-0.0.6.tgz#fbf1d5b6747ad46f520a9333578de053063c3153"
-  dependencies:
-    broccoli-caching-writer "2.2.1"
-    compass-compile "0.0.1"
-    merge "^1.2.0"
 
 broccoli-concat@^3.2.2:
   version "3.2.2"
@@ -1271,23 +1250,6 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz#12cb76e342343592a3b18ae7840c0db3bd16d8af"
-  dependencies:
-    array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^1.0.0"
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.0"
-    fs-tree-diff "^0.3.0"
-    minimatch "^2.0.1"
-    mkdirp "^0.5.0"
-    path-posix "^1.0.0"
-    rimraf "^2.4.3"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.2.6"
-
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
@@ -1332,18 +1294,6 @@ broccoli-lint-eslint@^3.3.0:
     json-stable-stringify "^1.0.1"
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
-
-broccoli-merge-trees@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz#1e283d18c686da922bb91a80d7aac0d161388e21"
-  dependencies:
-    broccoli-plugin "^1.0.0"
-    can-symlink "^1.0.0"
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.2"
-    fs-tree-diff "^0.4.3"
-    rimraf "^2.4.3"
-    symlink-or-copy "^1.0.0"
 
 broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.2.0:
   version "1.2.4"
@@ -1789,14 +1739,6 @@ commoner@~0.10.3:
     q "^1.1.2"
     recast "^0.11.17"
 
-compass-compile@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/compass-compile/-/compass-compile-0.0.1.tgz#a078a7c0d43c20f7be47bb9122a98aa70261c930"
-  dependencies:
-    dargs "^4.0.1"
-    merge "^1.2.0"
-    rsvp "^3.1.0"
-
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -1962,12 +1904,6 @@ d@1:
 dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
-
-dargs@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
-  dependencies:
-    number-is-nan "^1.0.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2195,17 +2131,6 @@ ember-cli-broccoli-sane-watcher@^2.0.4:
     heimdalljs-logger "^0.1.7"
     rsvp "^3.0.18"
     sane "^1.1.1"
-
-ember-cli-compass-compiler@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-compass-compiler/-/ember-cli-compass-compiler-0.5.0.tgz#b44000846f9e04b077042f9fb0fd67ae1a4c072e"
-  dependencies:
-    broccoli-compass-compiler "0.0.6"
-    broccoli-funnel "1.0.1"
-    broccoli-merge-trees "1.1.1"
-    ember-cli-version-checker "^1.1.4"
-    glob "^6.0.4"
-    merge "^1.2.0"
 
 ember-cli-dependency-checker@^1.3.0:
   version "1.4.0"
@@ -3322,20 +3247,6 @@ fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
 
-fs-tree-diff@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz#41a84ee34994bd564c63d9852f1109c5de7f9290"
-  dependencies:
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.2"
-
-fs-tree-diff@^0.4.3:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz#f6b75d70db22c1f3b05d592270f4ed6c9c2f82dd"
-  dependencies:
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.2"
-
 fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.6.tgz#342665749e8dca406800b672268c8f5073f3e623"
@@ -3451,16 +3362,6 @@ glob@7.1.1:
 glob@^5.0.10, glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -4479,7 +4380,7 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-merge@^1.1.3, merge@^1.2.0:
+merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -4525,7 +4426,7 @@ mime@1.3.4, mime@^1.2.11:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^2.0.1, minimatch@^2.0.3:
+minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
@@ -4769,9 +4670,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nypr-ui@nypublicradio/nypr-ui#node-sass:
+nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/74835c61a1bf1489f7f002b0b81b5630b37874d4"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/978b09c9926dbf738c8cfbebbfecefa4136e7fd9"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"
@@ -6232,7 +6133,7 @@ walk-sync@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.1.3.tgz#8a07261a00bda6cfb1be25e9f100fad57546f583"
 
-walk-sync@^0.2.5, walk-sync@^0.2.6, walk-sync@^0.2.7:
+walk-sync@^0.2.5, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   dependencies:


### PR DESCRIPTION
Compass is no longer supported. This PR swaps `ember-cli-compass-compiler` for `ember-cli-sass`.

This PR also currently depends on the `#node-sass` branch of `nypr-ui`, which should be updated before merging.

Update package and lockfile when nypublicradio/nypr-ui#66 merges.